### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,11 @@ ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 8.0 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
+# Repair GPG error
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
 RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -17,7 +22,7 @@ RUN pip install mmcv-full==1.4.7 -f https://download.openmmlab.com/mmcv/dist/cu1
 RUN pip install mmsegmentation mmdet
 # Install OpenMixup
 RUN conda clean --all
-RUN git clone https://github.com/Westlake-AI/openmixup.git  /mmselfsup
+RUN git clone https://github.com/Westlake-AI/openmixup.git  /openmixup
 WORKDIR /openmixup
 ENV FORCE_CUDA="1"
 RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
## Motivation

There are two problems with the current Dockerfile, which will break the building process:
1. Run `apt-get update` directly in an nvidia docker may lead to a GPG error.

```shell
W: GPG error: https://developer.download.nvidia.cn/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
The command '/bin/sh -c apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6     && apt-get clean     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
(
```

3. Working directory was mismatched in the following [codes](https://github.com/Westlake-AI/openmixup/blob/90dab92464e94ac5c4139c37f07ed21df9c2affb/docker/Dockerfile#L20-L21)

```dockerfile
RUN git clone https://github.com/Westlake-AI/openmixup.git  /mmselfsup
WORKDIR /openmixup
```


## Modification

1. Repair GPG error manually:
```dockerfile
# Repair GPG error
RUN apt-key del 7fa2af80
RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
```

2. Update working directory:
```dockerfile
RUN git clone https://github.com/Westlake-AI/openmixup.git  /openmixup
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
